### PR TITLE
[CM-1318] Add key command for navigation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "YCarousel",
+    defaultLocalization: "en",
     platforms: [
         .iOS(.v14)
     ],
@@ -16,7 +17,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.5.0"
+            from: "1.6.0"
         )
     ],
     targets: [

--- a/Sources/YCarousel/Assets/Strings/en.lproj/Localizable.strings
+++ b/Sources/YCarousel/Assets/Strings/en.lproj/Localizable.strings
@@ -1,0 +1,9 @@
+/* 
+  Localizable.strings
+  
+
+  Created by Sahil Saini on 05/04/23.
+  
+*/
+"Previous_Arrow_Button" = "Previous";
+"Next_Arrow_Button" = "Next";

--- a/Sources/YCarousel/CarouselView.swift
+++ b/Sources/YCarousel/CarouselView.swift
@@ -50,7 +50,7 @@ public class CarouselView: UIView {
             }
         }
     }
-    
+
     private let pageControlBottomSpacing: CGFloat = 16
     private var viewProvider: CarouselViewProvider?
 
@@ -120,7 +120,7 @@ public class CarouselView: UIView {
     }
 
     /// Load view at index
-    /// - Parameter index: index of view
+    /// - Parameter index: index of view to load
     public func loadView(at index: Int) {
         guard 0..<numberOfPages ~= index else {
             return

--- a/Sources/YCarousel/CarouselView.swift
+++ b/Sources/YCarousel/CarouselView.swift
@@ -118,6 +118,16 @@ public class CarouselView: UIView {
         }
         return nil
     }
+
+    /// Load view at index
+    /// - Parameter index: index of view
+    public func loadView(at index: Int) {
+        guard 0..<numberOfPages ~= index else {
+            return
+        }
+        currentPage = index
+        gotoPage(at: index)
+    }
 }
 
 internal extension CarouselView {

--- a/Sources/YCarousel/CarouselViewController.swift
+++ b/Sources/YCarousel/CarouselViewController.swift
@@ -12,8 +12,8 @@ import UIKit
 public class CarouselViewController: UIViewController, CarouselViewDelegate, CarouselViewDataSource {
     private let pages: [CarouselPage]
 
-    /// Disables key commands. Default is `false`.
-    public var disableKeyCommand: Bool = false
+    /// Enables keyboard navigation. Default is `true`.
+    public var isKeyboardNavigationEnabled: Bool = true
 
     /// The carousel view managed by this controller
     public var carouselView: CarouselView! { view as? CarouselView }
@@ -120,16 +120,12 @@ internal extension CarouselViewController {
     }
 
     @objc func leftArrowKeyPressed() {
-        if disableKeyCommand {
-            return
-        }
+        guard isKeyboardNavigationEnabled else { return }
         self.carouselView.loadView(at: carouselView.currentPage - 1)
     }
 
     @objc func rightArrowKeyPressed() {
-        if disableKeyCommand {
-            return
-        }
+        guard isKeyboardNavigationEnabled else { return }
         self.carouselView.loadView(at: carouselView.currentPage + 1)
     }
 }

--- a/Sources/YCarousel/CarouselViewController.swift
+++ b/Sources/YCarousel/CarouselViewController.swift
@@ -12,6 +12,9 @@ import UIKit
 public class CarouselViewController: UIViewController, CarouselViewDelegate, CarouselViewDataSource {
     private let pages: [CarouselPage]
 
+    /// Disables key commands. Default is `false`.
+    public var disableKeyCommand: Bool = false
+
     /// The carousel view managed by this controller
     public var carouselView: CarouselView! { view as? CarouselView }
 
@@ -37,6 +40,7 @@ public class CarouselViewController: UIViewController, CarouselViewDelegate, Car
         carouselView.dataSource = self
         carouselView.delegate = self
         self.view = carouselView
+        setKeys()
     }
 
     // MARK: - CarouselViewDelegate
@@ -94,4 +98,38 @@ public class CarouselViewController: UIViewController, CarouselViewDelegate, Car
     /// - Parameter index: Indicates the index of a page.
     /// - Returns: UIView
     public func carouselView(pageAt index: Int) -> UIView { pages[index].view }
+}
+
+// MARK: - UIKeyCommand
+
+internal extension CarouselViewController {
+    func setKeys() {
+        let rightArrow = UIKeyCommand(
+            title: CarouselViewController.Strings.next.localized,
+            action: #selector(rightArrowKeyPressed),
+            input: UIKeyCommand.inputRightArrow
+        )
+        let leftArrow = UIKeyCommand(
+            title: CarouselViewController.Strings.previous.localized,
+            action: #selector(leftArrowKeyPressed),
+            input: UIKeyCommand.inputLeftArrow
+        )
+        
+        addKeyCommand(leftArrow)
+        addKeyCommand(rightArrow)
+    }
+
+    @objc func leftArrowKeyPressed() {
+        if disableKeyCommand {
+            return
+        }
+        self.carouselView.loadView(at: carouselView.currentPage - 1)
+    }
+
+    @objc func rightArrowKeyPressed() {
+        if disableKeyCommand {
+            return
+        }
+        self.carouselView.loadView(at: carouselView.currentPage + 1)
+    }
 }

--- a/Sources/YCarousel/CarouselViewController.swift
+++ b/Sources/YCarousel/CarouselViewController.swift
@@ -40,7 +40,7 @@ public class CarouselViewController: UIViewController, CarouselViewDelegate, Car
         carouselView.dataSource = self
         carouselView.delegate = self
         self.view = carouselView
-        setKeys()
+        configureKeys()
     }
 
     // MARK: - CarouselViewDelegate
@@ -103,7 +103,7 @@ public class CarouselViewController: UIViewController, CarouselViewDelegate, Car
 // MARK: - UIKeyCommand
 
 internal extension CarouselViewController {
-    func setKeys() {
+    func configureKeys() {
         let rightArrow = UIKeyCommand(
             title: CarouselViewController.Strings.next.localized,
             action: #selector(rightArrowKeyPressed),
@@ -114,18 +114,17 @@ internal extension CarouselViewController {
             action: #selector(leftArrowKeyPressed),
             input: UIKeyCommand.inputLeftArrow
         )
-        
         addKeyCommand(leftArrow)
         addKeyCommand(rightArrow)
     }
 
     @objc func leftArrowKeyPressed() {
         guard isKeyboardNavigationEnabled else { return }
-        self.carouselView.loadView(at: carouselView.currentPage - 1)
+        carouselView.loadView(at: carouselView.currentPage - 1)
     }
 
     @objc func rightArrowKeyPressed() {
         guard isKeyboardNavigationEnabled else { return }
-        self.carouselView.loadView(at: carouselView.currentPage + 1)
+        carouselView.loadView(at: carouselView.currentPage + 1)
     }
 }

--- a/Sources/YCarousel/Enums/CarouselViewController+Strings.swift
+++ b/Sources/YCarousel/Enums/CarouselViewController+Strings.swift
@@ -1,0 +1,22 @@
+//
+//  CarouselViewController+Strings.swift
+//  YCarousel
+//
+//  Created by Sahil Saini on 05/04/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+import YCoreUI
+
+extension CarouselViewController {
+    /// Strings
+    enum Strings: String, Localizable, CaseIterable {
+        /// Buttons
+        case previous = "Previous_Arrow_Button"
+        case next = "Next_Arrow_Button"
+
+        /// Bundle
+        static var bundle: Bundle { .module }
+    }
+}

--- a/Tests/YCarouselTests/CarouselViewControllerTests.swift
+++ b/Tests/YCarouselTests/CarouselViewControllerTests.swift
@@ -83,7 +83,7 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertTrue(sut.pageWillUnload)
     }
 
-    func test_keycommand() {
+    func test_press_keyboard_left_atindex_zero() {
         let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
         XCTAssertEqual(sut.carouselView.pages.count, 2)
 
@@ -93,15 +93,47 @@ final class CarouselViewControllerTests: XCTestCase {
         sut.leftArrowKeyPressed()
 
         XCTAssertEqual(sut.carouselView.currentPage, 0)
-        // right key pressed more than number of pages, at index 0
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, sut.carouselView.pages.count-1)
     }
 
-    func test_keycommand_disable() {
+    func test_press_keyboard_left_atindex_non_zero() {
+        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // right key pressed twice to be at index 2
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // left key pressed to be back at 0
+        sut.leftArrowKeyPressed()
+        sut.leftArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
+    }
+
+    func test_press_keyboard_right_atindex_zero() {
+        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // right key pressed more than once, at index 0
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+    }
+
+    func test_press_keyboard_right_atindex_non_zero() {
+        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // right key pressed more than numberOfPages
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+    }
+
+    func test_keyboard_disable() {
         let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
         XCTAssertEqual(sut.carouselView.pages.count, 2)
 
@@ -111,7 +143,7 @@ final class CarouselViewControllerTests: XCTestCase {
 
         XCTAssertEqual(sut.carouselView.currentPage, 2)
 
-        sut.disableKeyCommand = true
+        sut.isKeyboardNavigationEnabled = false
         // after disable, no change in current page
         sut.leftArrowKeyPressed()
         XCTAssertEqual(sut.carouselView.currentPage, 2)
@@ -119,7 +151,7 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.carouselView.currentPage, 2)
     }
 
-    func test_keycommand_with_vc() {
+    func test_keycommand_left_with_vc_at_zero_index() {
         let sut = makeSUT(withViewControllers: [
             UIViewController(),
             UIViewController(),
@@ -133,6 +165,16 @@ final class CarouselViewControllerTests: XCTestCase {
         sut.leftArrowKeyPressed()
 
         XCTAssertEqual(sut.carouselView.currentPage, 0)
+    }
+    
+    func test_keycommand_right_with_vc_at_zero_index() {
+        let sut = makeSUT(withViewControllers: [
+            UIViewController(),
+            UIViewController(),
+            UIViewController()
+        ])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
         // right key pressed more than number of pages, at index 0
         sut.rightArrowKeyPressed()
         sut.rightArrowKeyPressed()
@@ -155,7 +197,7 @@ final class CarouselViewControllerTests: XCTestCase {
 
         XCTAssertEqual(sut.carouselView.currentPage, 2)
 
-        sut.disableKeyCommand = true
+        sut.isKeyboardNavigationEnabled = false
         // after disable, no change in current page
         sut.leftArrowKeyPressed()
         XCTAssertEqual(sut.carouselView.currentPage, 2)

--- a/Tests/YCarouselTests/CarouselViewControllerTests.swift
+++ b/Tests/YCarouselTests/CarouselViewControllerTests.swift
@@ -82,6 +82,86 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertTrue(sut.pageWillUnload)
         XCTAssertTrue(sut.pageWillUnload)
     }
+
+    func test_keycommand() {
+        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // left key pressed more than once, at index 0
+        sut.leftArrowKeyPressed()
+        sut.leftArrowKeyPressed()
+        sut.leftArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
+        // right key pressed more than number of pages, at index 0
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, sut.carouselView.pages.count-1)
+    }
+
+    func test_keycommand_disable() {
+        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // before disable
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+
+        sut.disableKeyCommand = true
+        // after disable, no change in current page
+        sut.leftArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        sut.rightArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+    }
+
+    func test_keycommand_with_vc() {
+        let sut = makeSUT(withViewControllers: [
+            UIViewController(),
+            UIViewController(),
+            UIViewController()
+        ])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // left key pressed more than once, at index 0
+        sut.leftArrowKeyPressed()
+        sut.leftArrowKeyPressed()
+        sut.leftArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
+        // right key pressed more than number of pages, at index 0
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, sut.carouselView.pages.count-1)
+    }
+
+    func test_keycommand_disable_with_vc() {
+        let sut = makeSUT(withViewControllers: [
+            UIViewController(),
+            UIViewController(),
+            UIViewController()
+        ])
+        XCTAssertEqual(sut.carouselView.pages.count, 2)
+
+        // before disable
+        sut.rightArrowKeyPressed()
+        sut.rightArrowKeyPressed()
+
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+
+        sut.disableKeyCommand = true
+        // after disable, no change in current page
+        sut.leftArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        sut.rightArrowKeyPressed()
+        XCTAssertEqual(sut.carouselView.currentPage, 2)
+    }
 }
 
 private extension CarouselViewControllerTests {

--- a/Tests/YCarouselTests/CarouselViewControllerTests.swift
+++ b/Tests/YCarouselTests/CarouselViewControllerTests.swift
@@ -83,126 +83,65 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertTrue(sut.pageWillUnload)
     }
 
-    func test_press_keyboard_left_atindex_zero() {
-        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // left key pressed more than once, at index 0
+    func test_pressKeyboardLeft_deliversPreviousPage() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
+        sut.carouselView.loadPage(at: 1)
+        // When
         sut.leftArrowKeyPressed()
-        sut.leftArrowKeyPressed()
-        sut.leftArrowKeyPressed()
-
+        // Then
         XCTAssertEqual(sut.carouselView.currentPage, 0)
     }
 
-    func test_press_keyboard_left_atindex_non_zero() {
-        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // right key pressed twice to be at index 2
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
-        // left key pressed to be back at 0
+    func test_pressKeyboardLeftOnFirstPage_deliversNothing() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
+        // When
         sut.leftArrowKeyPressed()
-        sut.leftArrowKeyPressed()
+        // Then
         XCTAssertEqual(sut.carouselView.currentPage, 0)
     }
 
-    func test_press_keyboard_right_atindex_zero() {
-        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // right key pressed more than once, at index 0
+    func test_pressKeyboardRight_deliversNextPage() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
+        // When
         sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // Then
+        XCTAssertEqual(sut.carouselView.currentPage, 1)
     }
 
-    func test_press_keyboard_right_atindex_non_zero() {
-        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // right key pressed more than numberOfPages
+    func test_pressKeyboardRightFromLastPage_deliversNothing() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
+        sut.carouselView.loadView(at: 1)
+        // When
         sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // Then
+        XCTAssertEqual(sut.carouselView.currentPage, 1)
     }
 
-    func test_keyboard_disable() {
-        let sut = makeSUT(withViews: [UIView(), UIView(), UIView()])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // before disable
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
-
+    func test_pressKeyboardLeftWhenDisabled_DeliversNothing() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
+        sut.carouselView.loadView(at: 1)
         sut.isKeyboardNavigationEnabled = false
-        // after disable, no change in current page
+        // When
         sut.leftArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
-        sut.rightArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // Then
+        XCTAssertEqual(sut.carouselView.currentPage, 1)
     }
 
-    func test_keycommand_left_with_vc_at_zero_index() {
-        let sut = makeSUT(withViewControllers: [
-            UIViewController(),
-            UIViewController(),
-            UIViewController()
-        ])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // left key pressed more than once, at index 0
-        sut.leftArrowKeyPressed()
-        sut.leftArrowKeyPressed()
-        sut.leftArrowKeyPressed()
-
-        XCTAssertEqual(sut.carouselView.currentPage, 0)
-    }
-    
-    func test_keycommand_right_with_vc_at_zero_index() {
-        let sut = makeSUT(withViewControllers: [
-            UIViewController(),
-            UIViewController(),
-            UIViewController()
-        ])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // right key pressed more than number of pages, at index 0
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, sut.carouselView.pages.count-1)
-    }
-
-    func test_keycommand_disable_with_vc() {
-        let sut = makeSUT(withViewControllers: [
-            UIViewController(),
-            UIViewController(),
-            UIViewController()
-        ])
-        XCTAssertEqual(sut.carouselView.pages.count, 2)
-
-        // before disable
-        sut.rightArrowKeyPressed()
-        sut.rightArrowKeyPressed()
-
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
-
+    func test_pressKeyboardRightWhenDisabled_DeliversNothing() {
+        // Given
+        let sut = makeSUT(withViews: [UIView(), UIView()])
         sut.isKeyboardNavigationEnabled = false
-        // after disable, no change in current page
-        sut.leftArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // When
         sut.rightArrowKeyPressed()
-        XCTAssertEqual(sut.carouselView.currentPage, 2)
+        // Then
+        XCTAssertEqual(sut.carouselView.currentPage, 0)
     }
 }
 

--- a/Tests/YCarouselTests/CarouselViewControllerTests.swift
+++ b/Tests/YCarouselTests/CarouselViewControllerTests.swift
@@ -123,7 +123,7 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.carouselView.currentPage, 1)
     }
 
-    func test_pressKeyboardLeftWhenDisabled_DeliversNothing() {
+    func test_pressKeyboardLeftWhenDisabled_deliversNothing() {
         // Given
         let sut = makeSUT(withViews: [UIView(), UIView()])
         sut.carouselView.loadView(at: 1)
@@ -134,7 +134,7 @@ final class CarouselViewControllerTests: XCTestCase {
         XCTAssertEqual(sut.carouselView.currentPage, 1)
     }
 
-    func test_pressKeyboardRightWhenDisabled_DeliversNothing() {
+    func test_pressKeyboardRightWhenDisabled_deliversNothing() {
         // Given
         let sut = makeSUT(withViews: [UIView(), UIView()])
         sut.isKeyboardNavigationEnabled = false

--- a/Tests/YCarouselTests/Enums/CarouselViewController+StringsTests.swift
+++ b/Tests/YCarouselTests/Enums/CarouselViewController+StringsTests.swift
@@ -1,0 +1,23 @@
+//
+//  CarouselViewController+StringsTests.swift
+//  YCarousel
+//
+//  Created by Sahil Saini on 07/04/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YCarousel
+
+final class CarouselViewControllerStringsTests: XCTestCase {
+    func testLoadStrings() {
+        CarouselViewController.Strings.allCases.forEach {
+            // Given a localized string constant
+            let string = $0.localized
+            // should not be empty
+            XCTAssertFalse(string.isEmpty)
+            // should not equal its key
+            XCTAssertNotEqual($0.rawValue, string)
+        }
+    }
+}


### PR DESCRIPTION
## Introduction ##

Added key command support for navigation. Now user will be able to move to different pages with the help of left and right arrow key of keyboard attached to device.
User can disable the key command by setting the flag `disableKeyCommond` to true.
Updated dependency to latest version.
## Purpose ##

Provide support for arrow keys.
Fix https://github.com/yml-org/ycarousel-ios/issues/2

## 📈 Coverage ##

##### Code #####

100%
<img width="1094" alt="Code coverage" src="https://user-images.githubusercontent.com/111066844/230056206-2a8d7a98-d587-43e0-ad50-a129c34b238e.png">

##### Documentation #####

100%
<img width="417" alt="jazzy" src="https://user-images.githubusercontent.com/111066844/230056326-9a95e117-610d-4f33-a38d-34ef3d050a14.png">
